### PR TITLE
Add other user profile screen with shared level overview

### DIFF
--- a/lib/src/features/home/home_screen.dart
+++ b/lib/src/features/home/home_screen.dart
@@ -7,9 +7,9 @@ import 'package:levelup/src/features/settings/settings_screen.dart';
 import 'package:levelup/src/shared/habit_card.dart';
 
 import '../../shared/xp_logic.dart';
-import '../../shared/widgets.dart';
 import '../leaderboard/leaderboard_screen.dart';
 import '../stats/stats_screen.dart';
+import 'widgets/level_overview.dart';
 
 // WICHTIG: Auth-Provider importieren, damit wir den Auth-State in den Streams beobachten
 import '../auth/auth_gate.dart';
@@ -70,7 +70,7 @@ class HomeScreen extends ConsumerWidget {
 
             return Padding(
               padding: const EdgeInsets.only(left: 12),
-              child: _LevelBadge(level: level),
+              child: LevelBadge(level: level),
             );
           },
           loading: () => const SizedBox.shrink(),
@@ -125,7 +125,7 @@ class HomeScreen extends ConsumerWidget {
                   ? data!['totalLevel'] as int
                   : levelFromXP(totalXP);
 
-              return _LevelHeaderCard(
+              return UserLevelOverview(
                 totalXp: totalXP,
                 level: level,
                 categoryXp: categoryXp,
@@ -209,271 +209,5 @@ class HomeScreen extends ConsumerWidget {
         child: const Icon(Icons.add, color: Colors.black),
       ),
     );
-  }
-}
-
-class _LevelHeaderCard extends StatelessWidget {
-  const _LevelHeaderCard({
-    required this.totalXp,
-    required this.level,
-    required this.categoryXp,
-  });
-
-  final int totalXp;
-  final int level;
-  final Map<String, dynamic> categoryXp;
-
-  int _cumulative(int l) => 60 * l * (l + 1) ~/ 2;
-
-  @override
-  Widget build(BuildContext context) {
-    final currentBase = _cumulative(level);
-    final nextNeed = _cumulative(level + 1);
-    final span = (nextNeed - currentBase).clamp(1, 1 << 31);
-    final progress = ((totalXp - currentBase) / span).clamp(0.0, 1.0);
-    final toNext = nextNeed - totalXp;
-
-    const stages = ['🌱', '🌿', '🌳', '🏯', '🚀', '🌌'];
-    final stage = (level / 3).floor().clamp(0, 5);
-
-    final entries = categoryXp.entries
-        .map((e) => MapEntry(
-              e.key,
-              (e.value is int)
-                  ? e.value as int
-                  : int.tryParse('${e.value}') ?? 0,
-            ))
-        .toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12.0),
-      child: glass(
-        padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Text(stages[stage], style: const TextStyle(fontSize: 52)),
-            const SizedBox(height: 8),
-
-            const Text('Level', style: TextStyle(color: Color(0xFF9fb3c8))),
-            Text(
-              '$level',
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                fontWeight: FontWeight.w900,
-                fontSize: 26,
-              ),
-            ),
-            const SizedBox(height: 4),
-
-            const SizedBox(height: 14),
-            
-            // Gesamt-XP Balken kleiner machen und zentrieren
-            Center(
-              child: SizedBox(
-                width: 200, // Feste, kleinere Breite
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(12),
-                  child: LinearProgressIndicator(
-                    value: progress,
-                    minHeight: 12,
-                  ),
-                ),
-              ),
-            ),
-
-            const SizedBox(height: 8),
-            Text(
-              '$toNext XP bis Level-Up',
-              textAlign: TextAlign.center,
-              style: const TextStyle(color: Color(0xFF9fb3c8)),
-            ),
-
-            if (entries.isNotEmpty) ...[
-              const SizedBox(height: 18),
-              _CategoryProgressRow(entries: entries),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _CategoryProgressRow extends StatelessWidget {
-  const _CategoryProgressRow({
-    required this.entries,
-  });
-
-  final List<MapEntry<String, int>> entries;
-
-  static const _categoryMeta = <String, Map<String, dynamic>>{
-    'Body': {'icon': Icons.fitness_center, 'color': Color(0xFF6C63FF)},
-    'Mind': {'icon': Icons.psychology, 'color': Color(0xFF00BFA6)},
-    'Social': {'icon': Icons.groups_rounded, 'color': Color(0xFFFB8C00)},
-    'Wellness': {'icon': Icons.self_improvement, 'color': Color(0xFFEC407A)},
-    'Work': {'icon': Icons.work, 'color': Color(0xFF42A5F5)},
-  };
-
-  @override
-  Widget build(BuildContext context) {
-    final sortedEntries = entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
-    final top5Entries = sortedEntries.take(5).toList();
-
-    return Center(
-      child: Wrap(
-        spacing: 12,
-        runSpacing: 12,
-        alignment: WrapAlignment.center,
-        children: top5Entries.map((entry) {
-          final category = entry.key;
-          final totalXp = entry.value;
-          final level = levelFromXP(totalXp);
-          final currentLevelStart = 60 * level * (level + 1) ~/ 2;
-          final nextLevelXP = 60 * (level + 1) * (level + 2) ~/ 2;
-          final xpInCurrentLevel = totalXp - currentLevelStart;
-          final xpNeededForNextLevel = nextLevelXP - currentLevelStart;
-          final progress = xpNeededForNextLevel > 0
-              ? xpInCurrentLevel / xpNeededForNextLevel
-              : 0.0;
-          final remainingXp = nextLevelXP - totalXp;
-
-          final meta = _categoryMeta[category];
-          final iconData = meta?['icon'] ?? Icons.category;
-          final color = meta?['color'] ?? Theme.of(context).colorScheme.secondary;
-
-          return _CategoryProgressCard(
-            category: category,
-            level: level,
-            totalXp: totalXp,
-            remainingXp: remainingXp,
-            progress: progress,
-            iconData: iconData,
-            color: color,
-          );
-        }).toList(),
-      ),
-    );
-  }
-}
-
-class _CategoryProgressCard extends StatelessWidget {
-  const _CategoryProgressCard({
-    required this.category,
-    required this.level,
-    required this.totalXp,
-    required this.remainingXp,
-    required this.progress,
-    required this.iconData,
-    required this.color,
-  });
-
-  final String category;
-  final int level;
-  final int totalXp;
-  final int remainingXp;
-  final double progress;
-  final IconData iconData;
-  final Color color;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return Container(
-      width: (MediaQuery.of(context).size.width / 2) - 24,
-      constraints: const BoxConstraints(maxWidth: 150),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceVariant.withOpacity(0.35),
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: theme.colorScheme.outlineVariant, width: 1),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.06),
-            blurRadius: 10,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      padding: const EdgeInsets.all(12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(iconData, size: 24, color: color),
-          const SizedBox(height: 8),
-          Text(
-            category,
-            textAlign: TextAlign.center,
-            style: theme.textTheme.titleMedium!.copyWith(
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Lvl $level',
-            textAlign: TextAlign.center,
-            style: theme.textTheme.bodySmall,
-          ),
-          const SizedBox(height: 8),
-          SizedBox(
-            width: double.infinity,
-            child: LinearProgressIndicator(
-              value: progress.clamp(0.0, 1.0),
-              minHeight: 6,
-              borderRadius: BorderRadius.circular(4),
-              backgroundColor: color.withOpacity(0.3),
-              color: color,
-            ),
-          ),
-          const SizedBox(height: 6),
-          Text(
-            '+$remainingXp XP',
-            textAlign: TextAlign.center,
-            style: theme.textTheme.bodySmall!.copyWith(
-              color: theme.colorScheme.onSurface.withOpacity(0.7),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _LevelBadge extends StatelessWidget {
-  const _LevelBadge({required this.level});
-  final int level;
-
-  @override
-  Widget build(BuildContext context) {
-    final bg = Theme.of(context).colorScheme.surface;
-    final border = Theme.of(context).dividerColor.withOpacity(0.35);
-
-    return Container(
-        width: 40,
-        height: 40,
-        decoration: BoxDecoration(
-          color: bg.withOpacity(0.6),
-          shape: BoxShape.circle,
-          border: Border.all(color: border, width: 2),
-          boxShadow: const [
-            BoxShadow(
-              color: Colors.black38,
-              blurRadius: 8,
-              offset: Offset(0, 2),
-            )
-          ],
-        ),
-        child: Center(
-          child: Text(
-            '$level',
-            style: const TextStyle(
-              fontWeight: FontWeight.w900,
-              fontSize: 16,
-            ),
-          ),
-        ));
   }
 }

--- a/lib/src/features/home/widgets/level_overview.dart
+++ b/lib/src/features/home/widgets/level_overview.dart
@@ -1,0 +1,272 @@
+import 'package:flutter/material.dart';
+import 'package:levelup/src/shared/widgets.dart';
+import 'package:levelup/src/shared/xp_logic.dart';
+
+class UserLevelOverview extends StatelessWidget {
+  const UserLevelOverview({
+    super.key,
+    required this.totalXp,
+    required this.level,
+    required this.categoryXp,
+  });
+
+  final int totalXp;
+  final int level;
+  final Map<String, dynamic> categoryXp;
+
+  int _cumulative(int l) => 60 * l * (l + 1) ~/ 2;
+
+  @override
+  Widget build(BuildContext context) {
+    final currentBase = _cumulative(level);
+    final nextNeed = _cumulative(level + 1);
+    final span = (nextNeed - currentBase).clamp(1, 1 << 31);
+    final progress = ((totalXp - currentBase) / span).clamp(0.0, 1.0);
+    final toNext = nextNeed - totalXp;
+
+    const stages = ['🌱', '🌿', '🌳', '🏯', '🚀', '🌌'];
+    final stage = (level / 3).floor().clamp(0, 5);
+
+    final entries = categoryXp.entries
+        .map((e) => MapEntry(
+              e.key,
+              (e.value is int)
+                  ? e.value as int
+                  : int.tryParse('${e.value}') ?? 0,
+            ))
+        .toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      child: glass(
+        padding: const EdgeInsets.symmetric(vertical: 20, horizontal: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(stages[stage], style: const TextStyle(fontSize: 52)),
+            const SizedBox(height: 8),
+            const Text('Level', style: TextStyle(color: Color(0xFF9fb3c8))),
+            Text(
+              '$level',
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontWeight: FontWeight.w900,
+                fontSize: 26,
+              ),
+            ),
+            const SizedBox(height: 4),
+            const SizedBox(height: 14),
+            Center(
+              child: SizedBox(
+                width: 200,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    minHeight: 12,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '$toNext XP bis Level-Up',
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Color(0xFF9fb3c8)),
+            ),
+            if (entries.isNotEmpty) ...[
+              const SizedBox(height: 18),
+              CategoryProgressRow(entries: entries),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class CategoryProgressRow extends StatelessWidget {
+  const CategoryProgressRow({
+    super.key,
+    required this.entries,
+  });
+
+  final List<MapEntry<String, int>> entries;
+
+  static const _categoryMeta = <String, Map<String, dynamic>>{
+    'Body': {'icon': Icons.fitness_center, 'color': Color(0xFF6C63FF)},
+    'Mind': {'icon': Icons.psychology, 'color': Color(0xFF00BFA6)},
+    'Social': {'icon': Icons.groups_rounded, 'color': Color(0xFFFB8C00)},
+    'Wellness': {'icon': Icons.self_improvement, 'color': Color(0xFFEC407A)},
+    'Work': {'icon': Icons.work, 'color': Color(0xFF42A5F5)},
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final sortedEntries = entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final top5Entries = sortedEntries.take(5).toList();
+
+    return Center(
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 12,
+        alignment: WrapAlignment.center,
+        children: top5Entries.map((entry) {
+          final category = entry.key;
+          final totalXp = entry.value;
+          final level = levelFromXP(totalXp);
+          final currentLevelStart = 60 * level * (level + 1) ~/ 2;
+          final nextLevelXP = 60 * (level + 1) * (level + 2) ~/ 2;
+          final xpInCurrentLevel = totalXp - currentLevelStart;
+          final xpNeededForNextLevel = nextLevelXP - currentLevelStart;
+          final progress = xpNeededForNextLevel > 0
+              ? xpInCurrentLevel / xpNeededForNextLevel
+              : 0.0;
+          final remainingXp = nextLevelXP - totalXp;
+
+          final meta = _categoryMeta[category];
+          final iconData = meta?['icon'] ?? Icons.category;
+          final color =
+              meta?['color'] ?? Theme.of(context).colorScheme.secondary;
+
+          return CategoryProgressCard(
+            category: category,
+            level: level,
+            totalXp: totalXp,
+            remainingXp: remainingXp,
+            progress: progress,
+            iconData: iconData,
+            color: color,
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+
+class CategoryProgressCard extends StatelessWidget {
+  const CategoryProgressCard({
+    super.key,
+    required this.category,
+    required this.level,
+    required this.totalXp,
+    required this.remainingXp,
+    required this.progress,
+    required this.iconData,
+    required this.color,
+  });
+
+  final String category;
+  final int level;
+  final int totalXp;
+  final int remainingXp;
+  final double progress;
+  final IconData iconData;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      width: (MediaQuery.of(context).size.width / 2) - 24,
+      constraints: const BoxConstraints(maxWidth: 150),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.35),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: theme.colorScheme.outlineVariant, width: 1),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.06),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(iconData, size: 24, color: color),
+          const SizedBox(height: 8),
+          Text(
+            category,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleMedium!.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Lvl $level',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodySmall,
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            width: double.infinity,
+            child: LinearProgressIndicator(
+              value: progress.clamp(0.0, 1.0),
+              minHeight: 6,
+              borderRadius: BorderRadius.circular(4),
+              backgroundColor: color.withOpacity(0.3),
+              color: color,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '+$remainingXp XP',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodySmall!.copyWith(
+              color: theme.colorScheme.onSurface.withOpacity(0.7),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class LevelBadge extends StatelessWidget {
+  const LevelBadge({
+    super.key,
+    required this.level,
+  });
+
+  final int level;
+
+  @override
+  Widget build(BuildContext context) {
+    final bg = Theme.of(context).colorScheme.surface;
+    final border = Theme.of(context).dividerColor.withOpacity(0.35);
+
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: bg.withOpacity(0.6),
+        shape: BoxShape.circle,
+        border: Border.all(color: border, width: 2),
+        boxShadow: const [
+          BoxShadow(
+            color: Colors.black38,
+            blurRadius: 8,
+            offset: Offset(0, 2),
+          )
+        ],
+      ),
+      child: Center(
+        child: Text(
+          '$level',
+          style: const TextStyle(
+            fontWeight: FontWeight.w900,
+            fontSize: 16,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/leaderboard/leaderboard_screen.dart
+++ b/lib/src/features/leaderboard/leaderboard_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:levelup/src/shared/xp_logic.dart';
+import 'package:levelup/src/features/profile/user_profile_screen.dart';
 
 
 class LeaderboardScreen extends StatelessWidget {
@@ -52,19 +53,33 @@ class LeaderboardScreen extends StatelessWidget {
               final categoryXP =
                   (data['categoryXP'] ?? const {}) as Map<String, dynamic>;
 
-              return _LeaderboardTile(
-                rank: i + 1,
-                isYou: isYou,
-                name: displayName,
-                photoURL: photoURL,
-                totalXP: totalXP,
-                categoryXP: {
-                  'Body': (categoryXP['Body'] ?? 0) as num,
-                  'Mind': (categoryXP['Mind'] ?? 0) as num,
-                  'Social': (categoryXP['Social'] ?? 0) as num,
-                  'Wellness': (categoryXP['Wellness'] ?? 0) as num,
-                  'Work': (categoryXP['Work'] ?? 0) as num,
+              return GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => UserProfileScreen(
+                        userId: snap.id,
+                        initialDisplayName: displayName,
+                      ),
+                    ),
+                  );
                 },
+                child: _LeaderboardTile(
+                  rank: i + 1,
+                  isYou: isYou,
+                  name: displayName,
+                  photoURL: photoURL,
+                  totalXP: totalXP,
+                  categoryXP: {
+                    'Body': (categoryXP['Body'] ?? 0) as num,
+                    'Mind': (categoryXP['Mind'] ?? 0) as num,
+                    'Social': (categoryXP['Social'] ?? 0) as num,
+                    'Wellness': (categoryXP['Wellness'] ?? 0) as num,
+                    'Work': (categoryXP['Work'] ?? 0) as num,
+                  },
+                ),
               );
             },
           );

--- a/lib/src/features/profile/user_profile_screen.dart
+++ b/lib/src/features/profile/user_profile_screen.dart
@@ -1,0 +1,105 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../../shared/xp_logic.dart';
+import '../home/widgets/level_overview.dart';
+
+class UserProfileScreen extends StatelessWidget {
+  const UserProfileScreen({
+    super.key,
+    required this.userId,
+    this.initialDisplayName,
+  });
+
+  final String userId;
+  final String? initialDisplayName;
+
+  @override
+  Widget build(BuildContext context) {
+    final stream = FirebaseFirestore.instance
+        .collection('users')
+        .doc(userId)
+        .snapshots();
+
+    return StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+      stream: stream,
+      builder: (context, snapshot) {
+        final doc = snapshot.data;
+        final data = doc?.data();
+
+        final displayName = (data?['displayName'] ?? initialDisplayName ?? 'Profil')
+            .toString();
+
+        int? level;
+        int? totalXp;
+        Map<String, dynamic>? categoryXp;
+
+        if (doc != null && doc.exists && data != null) {
+          totalXp = (data['totalXP'] ?? 0) as int;
+          level = (data['totalLevel'] is int)
+              ? data['totalLevel'] as int
+              : levelFromXP(totalXp);
+          categoryXp = Map<String, dynamic>.from(data['categoryXP'] ?? const {});
+        }
+
+        Widget body;
+        if (snapshot.hasError) {
+          body = Center(child: Text('Fehler: ${snapshot.error}'));
+        } else if (!snapshot.hasData) {
+          body = const Center(child: CircularProgressIndicator());
+        } else if (doc == null || !doc.exists || data == null) {
+          body = const Center(child: Text('Nutzer wurde nicht gefunden.'));
+        } else {
+          body = ListView(
+            padding: const EdgeInsets.fromLTRB(12, 12, 12, 48),
+            children: [
+              UserLevelOverview(
+                totalXp: totalXp!,
+                level: level!,
+                categoryXp: categoryXp!,
+              ),
+            ],
+          );
+        }
+
+        Widget? leading;
+        double? leadingWidth;
+
+        if (Navigator.of(context).canPop()) {
+          if (level == null) {
+            leading = const BackButton();
+          } else {
+            leadingWidth = 96;
+            leading = Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const BackButton(),
+                const SizedBox(width: 4),
+                Padding(
+                  padding: const EdgeInsets.only(left: 4),
+                  child: LevelBadge(level: level),
+                ),
+              ],
+            );
+          }
+        } else if (level != null) {
+          leadingWidth = 56;
+          leading = Padding(
+            padding: const EdgeInsets.only(left: 12),
+            child: LevelBadge(level: level),
+          );
+        }
+
+        return Scaffold(
+          appBar: AppBar(
+            leadingWidth: leadingWidth,
+            leading: leading,
+            title: Text(displayName),
+            centerTitle: true,
+          ),
+          body: body,
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract the level overview UI into a reusable widget
- add a user profile screen to inspect another player's stats without favourites
- open the new profile screen from leaderboard entries

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c85ee08e58832d8f9772201f4f72ee